### PR TITLE
Added retry for pip install

### DIFF
--- a/recipes/awscli.rb
+++ b/recipes/awscli.rb
@@ -22,6 +22,8 @@ if node['commons']['install_awscli']
     include_recipe 'yum-epel::default'
     package "python-pip" do
       action :install
+      retries 10
+      retry_delay 60
     end
     execute "install-awscli" do
       command "pip install awscli --ignore-installed six"


### PR DESCRIPTION
Adding retry properties as described here: https://docs.chef.io/resource_common.html

I have a hunch that there's some sort of race condition between adding the epel yum repo and the repo actually being ready to access which is why I think it's happening intermittently. 